### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/AzureDevOpsRam/d11818e6-3ccf-4ad7-986a-d9e6817f6e75/53237590-579c-4f60-9c59-49a12f7447c6/_apis/work/boardbadge/b1bef9c1-93ed-412f-9471-600aace090f1)](https://dev.azure.com/AzureDevOpsRam/d11818e6-3ccf-4ad7-986a-d9e6817f6e75/_boards/board/t/53237590-579c-4f60-9c59-49a12f7447c6/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/AzureDevOpsRam/d11818e6-3ccf-4ad7-986a-d9e6817f6e75/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.